### PR TITLE
Optionally stop writing output ports when the end is reached

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -138,9 +138,10 @@ void Task::updateHook()
 
     //this state is checked before the follower status is evaluated, when the status is
     //REACHED_THE_END, the "stop" command is written once, before the WRITING_STOPPED state is entered
-	if ( state() == REACHED_THE_END){
-		if (_stopWriting.get()) {state(REACHED_THE_END_WRITING_STOPPED);}
-	}
+    if ( state() == REACHED_THE_END)
+    {
+        if (_stopWriting.get()) {state(REACHED_THE_END_WRITING_STOPPED);}
+    }
 
 
     Eigen::Vector2d motionCmd;    
@@ -158,7 +159,8 @@ void Task::updateHook()
 		    overwriteTrajectorySpeed(curTr, driveSpeed);
 		    trFollower->setNewTrajectory(curTr);
 		    trajectories.erase(trajectories.begin());
-	    } else
+	    }
+            else
 	    {
 		if(!(state() == REACHED_THE_END || state() == REACHED_THE_END_WRITING_STOPPED))
 		    state(REACHED_THE_END);
@@ -179,7 +181,8 @@ void Task::updateHook()
     mc.translation = motionCmd(0);
     mc.rotation    = motionCmd(1);
     
-    if (state() != REACHED_THE_END_WRITING_STOPPED){
+    if (state() != REACHED_THE_END_WRITING_STOPPED)
+    {
 		_motion_command.write(mc);
 		_currentCurvePoint.write(trFollower->getCurvePoint());
 		_poseError.write(trFollower->getControlError());

--- a/trajectory_follower.orogen
+++ b/trajectory_follower.orogen
@@ -56,6 +56,8 @@ task_context "Task" do
         
     property("noOrientationRotationalVelocity", "double", 0.0).
         doc "If greater than 0 the supported rotational velocity of controler type 0 will not exceed this limit"
+        
+    property('stopWriting', 'bool', false).doc "used the state REACHED_THE_END_WRITING_STOPPED, when the end is reached, no motion2d commands are written in this state"
 
     input_port("trajectory", "std::vector</base/Trajectory>").
         doc("Trajectory the robot should follow").
@@ -79,6 +81,9 @@ task_context "Task" do
     # Runtime state that is emitted when we reach the end of the curve, to
     # announce it to the outside world
     runtime_states :REACHED_THE_END
+
+	# Runtime state entered after REACHED_THE_END when the stopWriting property is set to true
+	runtime_states :REACHED_THE_END_WRITING_STOPPED
 
     # Runtime error state entered when the initial stability test failed for a
     # particular trajectory. Note that the component might switch back to


### PR DESCRIPTION
This allows e.g. joystick controls, when no trajectory is followed, must
be enabled by setting the stopWriting property to "true" (default:
"false")
