### PR TITLE
ignore input data containing degenerate splines

### DIFF
--- a/trajectory_follower.orogen
+++ b/trajectory_follower.orogen
@@ -39,6 +39,7 @@ task_context "Task" do
     # particular trajectory. Note that the component might switch back to
     # runtime state if a new trajectory / new pose is received
     error_states :STABILITY_FAILED
+    error_states :INVALID_INPUT_DATA
 
     needs_configuration
     port_driven


### PR DESCRIPTION
If a degenerate trajectory was received, component switched to exception state with:
```
44.476 [ ERROR  ][RemoteInputPort::buildRemoteChannelOutput] in updateHook(): switching to exception state because of unhandled exception
44.476 [ ERROR  ][RemoteInputPort::buildRemoteChannelOutput]   getFrenetFrame() called on an empty or degenerate curve
```

This fix identifies degenerated splines in the received trajectories and ignores them. It is made visible by changing the component to an error state and writing a message into the text log.

If a new trajectory is received, the component recovers and keeps on working as normal.