### PR TITLE
Add dependency to drivers/orogen/transformer to manifest

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -3,5 +3,6 @@
   <depend package="control/trajectory_follower"/>
   <depend package="base/orogen/types"/>
   <depend package="orogen"/>
+  <depend package="drivers/orogen/transformer"/>
   <tags>stable</tags>
 </package>


### PR DESCRIPTION
The [previous commit](https://github.com/rock-control/control-orogen-trajectory_follower/commit/e51c50791f85c761a2230b50fb1444661f6cf970#diff-a5674198385756c4059a082ea6eb0087) introduces the use of the transformer in the orogen file. This leads to the following error: `unknown statement 'transformer' (OroGen::ConfigError)`

Fixed by adding the transformer to the manifest.