### PR TITLE
add property to only send zero motion commands once

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -135,7 +135,13 @@ void Task::updateHook()
     }
     
     _follower_data.write(trajectoryFollower.getData());
-    _motion_command.write(motionCommand.toBaseMotion2D());
+    
+    if ( current_state != RUNNING &&
+         current_state != FINISHED_TRAJECTORIES &&
+         not _send_zero_cmd_once.value() )
+    {
+        _motion_command.write(motionCommand.toBaseMotion2D());
+    }
 
     // update task state
     if(current_state != new_state)

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -31,10 +31,12 @@ namespace trajectory_follower{
         std::vector<SubTrajectory> trajectories;
         TrajectoryFollower trajectoryFollower;
         Motion2D motionCommand;
+        Motion2D lastMotionCommand;
         States new_state;
         States current_state;
 
         std::string printState(const States& state);
+        bool isMotionCommandZero(const Motion2D& mc);
 
     public:
         /** TaskContext constructor for Task

--- a/trajectory_follower.orogen
+++ b/trajectory_follower.orogen
@@ -15,6 +15,9 @@ task_context "Task" do
     property("follower_config", "trajectory_follower/FollowerConfig" ).
             doc "Combined follower config"
 
+    property("send_zero_cmd_once", "bool", true).
+            doc "Don't send zero motion_commands repetitively"
+
     # Input ports
     input_port("trajectory", "std::vector<trajectory_follower/SubTrajectory>").
         doc("Trajectory the robot should follow").

--- a/trajectory_follower.orogen
+++ b/trajectory_follower.orogen
@@ -15,7 +15,7 @@ task_context "Task" do
     property("follower_config", "trajectory_follower/FollowerConfig" ).
             doc "Combined follower config"
 
-    property("send_zero_cmd_once", "bool", true).
+    property("send_zero_cmd_once", "bool", false).
             doc "Don't send zero motion_commands repetitively"
 
     # Input ports


### PR DESCRIPTION
The trajectory_follower repetitively sends zero_commands if no trajectory is to be followed. If several tasks are connected to a motion_controller this results in undesired behaviour as the trajectory_follower overwrites other motion commands.

I simply added a property to disable that behaviour, which is `false` by default so this PR should not have an effect on previous behaviour.

Would appreciate feedback on this.