### PR TITLE
Add TimeOut feature

### DIFF
--- a/tasks/Task.cpp
+++ b/tasks/Task.cpp
@@ -203,8 +203,6 @@ void Task::updateHook()
 void Task::errorHook()
 {
     TaskBase::errorHook();
-    Motion2D motionCommand{};
-    _motion_command.write(motionCommand.toBaseMotion2D());
 }
 
 void Task::stopHook()

--- a/tasks/Task.hpp
+++ b/tasks/Task.hpp
@@ -30,10 +30,10 @@ namespace trajectory_follower{
     protected:
         std::vector<SubTrajectory> trajectories;
         TrajectoryFollower trajectoryFollower;
-        Motion2D motionCommand;
         Motion2D lastMotionCommand;
-        States new_state;
-        States current_state;
+        States new_state = PRE_OPERATIONAL;
+        States current_state = PRE_OPERATIONAL;
+        base::Time lastPoseUpdate;
 
         std::string printState(const States& state);
         bool isMotionCommandZero(const Motion2D& mc);
@@ -55,7 +55,7 @@ namespace trajectory_follower{
 
         /** Default deconstructor of Task
          */
-	~Task();
+        ~Task();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the

--- a/trajectory_follower.orogen
+++ b/trajectory_follower.orogen
@@ -17,11 +17,16 @@ task_context "Task" do
 
     property("send_zero_cmd_once", "bool", false).
             doc "Don't send zero motion_commands repetitively"
+    property("send_zero_cmd_on_timeout", "bool", false).
+            doc "If no pose update arrived within `max_latency`, send a zero command to make the robot stop. By default, no command is send"
 
     # Input ports
     input_port("trajectory", "std::vector<trajectory_follower/SubTrajectory>").
         doc("Trajectory the robot should follow").
         needs_buffered_connection
+
+    input_port("simulated_time", "base::Time").
+        doc "When running on simulation or log data, you can connect this to a port which outputs the simulated current time. If this port is unconnected base::Time::now() is used."
 
     # Transformations
     transformer do
@@ -46,7 +51,7 @@ task_context "Task" do
         doc("Stops following the current trajectory. Will start following the next incoming trajectory")
 
     # Runtime state for when trajectory finished or when actively following one
-    runtime_states :FINISHED_TRAJECTORIES, :FOLLOWING_TRAJECTORY, :TURN_ON_SPOT, :LATERAL, :SLAM_POSE_INVALID
+    runtime_states :FINISHED_TRAJECTORIES, :FOLLOWING_TRAJECTORY, :TURN_ON_SPOT, :LATERAL, :SLAM_POSE_INVALID, :NO_POSITION_UPDATES
 
     # Runtime error state entered when the initial stability test failed for a
     # particular trajectory. Note that the component might switch back to


### PR DESCRIPTION
Added new state `NO_POSITION_UPDATES` and flag to stop when no input poses arrived for more than transformer_max_latency.
To be compatible with (possibly lagging) simulation time, also added a `simulated_time` port.

This can be slightly cleaned up, e.g., on timeout the whole trajectory follower logic does not need to be executed.
Also, maybe transformer_max_latency should not be re-used for this feature.